### PR TITLE
Small bug fix for traversal

### DIFF
--- a/neo4jrestclient/client.py
+++ b/neo4jrestclient/client.py
@@ -805,9 +805,9 @@ class Node(Base):
                 elif returns == RELATIONSHIP:
                     return Iterable(Relationship, results_list, "self")
                 elif returns == PATH:
-                    return Iterable(Path, results_list)
+                    return Iterable(Path, results_list, "self")
                 elif returns == POSITION:
-                    return Iterable(Position, results_list)
+                    return Iterable(Position, results_list, "self")
             elif response.status == 404:
                 raise NotFoundError(response.status, "Node or relationship " \
                                                      "not found")


### PR DESCRIPTION
Fixed bug in traverse method for POSITION and PATH return types. The Iterable object missed the attr parameter.
