### PR TITLE
use JSON object to set index key and value

### DIFF
--- a/neo4jrestclient/client.py
+++ b/neo4jrestclient/client.py
@@ -1015,8 +1015,12 @@ class Index(object):
                 url_ref = item.url
             else:
                 url_ref = item
-            request_url = "%s/%s" % (self.url, value)
-            response, content = Request().post(request_url, data=url_ref)
+            request_url_and_key = self.url.rsplit('/',1) # assumes the key
+            data = {"key": request_url_and_key[1], "value": value,
+                    "uri": url_ref}
+            headers = {"Content-Type":"application/json"}
+            response, content = Request().post(request_url_and_key[0],
+                                               data=data, headers=headers)
             if response.status == 201:
                 # Returns object that was indexed
                 entity = json.loads(content)


### PR DESCRIPTION
Fixes https://github.com/versae/neo4j-rest-client/issues/37 which I created. Please check the method I used to deconstruct the key from the IndexKey's self.url. There is probably a better way to get access to the key and url from the Index object.

This should be used with versions of neo4j that are at least as recent as 1.5.M02. see https://github.com/neo4j/community/issues/25 and http://docs.neo4j.org/chunked/snapshot/rest-api-indexes.html#rest-api-add-node-to-index
