### PR TITLE
traversal crash when returns='path'

### DIFF
--- a/neo4jrestclient/client.py
+++ b/neo4jrestclient/client.py
@@ -568,14 +568,14 @@ class Iterable(list):
 
     def __getslice__(self, *args, **kwargs):
         eltos = super(Iterable, self).__getslice__(*args, **kwargs)
-        if self._attribute:
+        if self._attribute in elto:
             return [self._class(elto[self._attribute]) for elto in eltos]
         else:
             return [self._class(elto) for elto in eltos]
 
     def __getitem__(self, index):
         elto = super(Iterable, self).__getitem__(index)
-        if self._attribute:
+        if self._attribute in elto:
             return self._class(elto[self._attribute])
         else:
             return self._class(elto)
@@ -592,7 +592,7 @@ class Iterable(list):
 
     def __contains__(self, value):
         if isinstance(value, Base) and hasattr(value, "url"):
-            if self._attribute:
+            if self._attribute in elto:
                 return value.url in [elto[self._attribute]
                                      for elto in self._list]
             else:


### PR DESCRIPTION
First: thanks for a great client.

For objects like Path, I see `Iterable.__getitem__` and related crashing at runtime because Path does not have a 'self' attribute. This seems like a conceptually sound design for Path, so I've tried to modify Iterable to handle this gracefully by returning the full object instead of an identifying attribute.

Please let me know if I'm missing something.
