### PR TITLE
Fix for paginated traversals under Neo4j 1.5

### DIFF
--- a/neo4jrestclient/client.py
+++ b/neo4jrestclient/client.py
@@ -862,7 +862,8 @@ class PaginatedTraversal(object):
                 response, content = Request().get(self._next_url)
                 if response.status == 200:
                     self._results = json.loads(content)
-                    self._next_url = response.get("location")
+                    self._next_url = response.get("location",
+                                         response.get("content-location"))
                 else:
                     self._next_url = None
             return results


### PR DESCRIPTION
Fix to check for 'content-location' header as well as 'location' header, fixing issue #44
