### PR TITLE
Fix bug in neo4jrestclient.client.Relationships

### DIFF
--- a/neo4jrestclient/client.py
+++ b/neo4jrestclient/client.py
@@ -1592,7 +1592,7 @@ class Relationships(object):
         self._dict = {}
         self._len = 0
 
-    def __getattr__(self, relationship_type):
+    def __getattr__(self, relationship_type, tx=None):
         auth = object.__getattribute__(self, "_auth")
 
         def get_relationships(types=None, *args, **kwargs):
@@ -1661,7 +1661,7 @@ class Relationships(object):
 
     def get(self, index, tx=None):
         tx = Transaction.get_transaction(tx)
-        return self.__getattr__(index, tx=tx)
+        return self.__getattr__(index)(tx=tx)
 
 
 class Relationship(Base):


### PR DESCRIPTION
Code was returning the result of **getattr**, which returns a function; it should have been returning the result of calling the returned function, consistent with **getitem** etc. This essentially rendered Relationships.get unusable.
