### PR TITLE
Ditch exception catch on root fetch at GraphDatabase.__init__()

### DIFF
--- a/neo4jrestclient/client.py
+++ b/neo4jrestclient/client.py
@@ -76,11 +76,7 @@ class GraphDatabase(object):
             self.url = url
         else:
             self.url = "%s/" % url
-        response, content = None, None
-        try:
-            response, content = Request(**self._auth).get(url)
-        except Exception:
-            raise NotFoundError(result="Unable get root")
+        response, content = Request(**self._auth).get(url)
         if response.status == 200:
             response_json = json.loads(content)
             self._relationship_index = response_json['relationship_index']


### PR DESCRIPTION
As per https://github.com/versae/neo4j-rest-client/issues/65, current
behaviour when auth fails is that a 401 StatusException is raised, and
caught by this try/except block and a misleading NotFoundError is raised
in its place - lets just let the StatusException through. Unsure about
what other Exceptions may be raised but cannot reproduce.
