### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -36,16 +36,16 @@ include other options:
 
 The next list shows all the current lookups supported:
 
-* `exact`, performs exact string comparation.
-* `iexact`, performs exact string comparation, case insesitive.
+* `exact`, performs exact string comparison.
+* `iexact`, performs exact string comparison, case insensitive.
 * `contains`, checks if the property is contained in the string passed.
-* `icontains`, as `contains` but case insesitive.
+* `icontains`, as `contains` but case insensitive.
 * `startswith`, checks if the property starts with the string passed.
-* `istartswith`, as `startswith` but case insesitive.
+* `istartswith`, as `startswith` but case insensitive.
 * `endswith`, checks if the property ends with the string passed.
-* `iendswith`, as `endswith` but case insesitive.
+* `iendswith`, as `endswith` but case insensitive.
 * `regex`, performs regular expression matching agains the string passed.
-* `iregex`, as `regex` but case insesitive.
+* `iregex`, as `regex` but case insensitive.
 * `gt`, check if the property is greater than the value passed.
 * `gte`, check if the property is greater than or equal to the value passed.
 * `lt`, check if the property is lower than the value passed.
@@ -53,9 +53,9 @@ The next list shows all the current lookups supported:
 * `in`, , check if the property is in a list of elements passed.
 * `inrange`,`an alias for `in`.
 * `isnull`, checks if the property is null, passing `True`, or not, passing `False`.
-* `eq`, performs equal comparations.
+* `eq`, performs equal comparisons.
 * `equals`, an alias `eq`.
-* `neq`, performs not equal comparations.
+* `neq`, performs not equal comparisons.
 * `notequals`, an alias `neq`.
 
 Also, in order to be compliant with Cypher syntax prior to Neo4j 2.0, you can

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,7 @@ The main class is ``GraphDatabase``, exactly how in python-embedded_:
 If ``/db/data/`` is not added, neo4j-rest-client will do an extra request in
 order to know the endpoint for data.
 
-And now we are ready to create nodes and relationhips:
+And now we are ready to create nodes and relationships:
 
   >>> alice = gdb.nodes.create(name="Alice", age=30)
 

--- a/docs/info.rst
+++ b/docs/info.rst
@@ -39,7 +39,7 @@ The main class is ``GraphDatabase``, exactly how in python-embedded_:
 If ``/db/data/`` is not added, neo4j-rest-client will do an extra request in
 order to know the endpoint for data.
 
-And now we are ready to create nodes and relationhips:
+And now we are ready to create nodes and relationships:
 
   >>> alice = gdb.nodes.create(name="Alice", age=30)
 

--- a/docs/transactions.rst
+++ b/docs/transactions.rst
@@ -88,7 +88,7 @@ executes it in a transaction, but there is no option to rollback and recover
 a previous status of the database. In this sense, batch-emulated transactions
 for operations on creation, edition and deletion of elements are useful, but
 you won't be able to perform checks on the elements modified until the batch
-is sent to the server and the transaction is commited.
+is sent to the server and the transaction is committed.
 
 
 Deletion
@@ -180,7 +180,7 @@ can be changed using de options:
 
 And this behaviour can be disabled adding the right param in the transaction:
 ``using_globals``. Even is possible (although not very recommendable) to handle
-different transactions in the same time and control when they are commited.
+different transactions in the same time and control when they are committed.
 There are many ways to set the transaction of a intruction (operation):
 
   >>> n = gdb.nodes.create()

--- a/neo4jrestclient/query.py
+++ b/neo4jrestclient/query.py
@@ -674,7 +674,7 @@ class QuerySequence(Sequence):
         if isinstance(self._limit, int) and "_limit" not in params:
             q = u"%s limit {_limit} " % q
             params["_limit"] = self._limit
-        # Making the real resquest
+        # Making the real request
         data = {
             "query": q,
             "params": params,
@@ -778,7 +778,7 @@ class QuerySequence(Sequence):
                 if "rest" in row:
                     row = row["rest"]
                 row = rewrites(row)
-                # We need both list to have the same lenght
+                # We need both list to have the same length
                 len_row = len(row)
                 len_returns = len(returns)
                 if len_row > len_returns:


### PR DESCRIPTION
There are small typos in:
- docs/filters.rst
- docs/index.rst
- docs/info.rst
- docs/transactions.rst
- neo4jrestclient/query.py

Fixes:
- Should read `insensitive` rather than `insesitive`.
- Should read `relationships` rather than `relationhips`.
- Should read `comparisons` rather than `comparations`.
- Should read `comparison` rather than `comparation`.
- Should read `committed` rather than `commited`.
- Should read `request` rather than `resquest`.
- Should read `length` rather than `lenght`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md