### PR TITLE
Fix python 3.10 imports

### DIFF
--- a/neo4jrestclient/query.py
+++ b/neo4jrestclient/query.py
@@ -3,7 +3,10 @@
 #                     /tree/master/sylva/engines/gdb/lookups
 import json
 import uuid
-from collections import Sequence
+try:
+    from collections.abc import MutableSet
+except ImportError:
+    from collections import MutableSet
 import warnings
 
 from neo4jrestclient.constants import RAW


### PR DESCRIPTION
Ran into an issue where a program that uses this library won't work on python3.10; This is all I needed to change for this specific program